### PR TITLE
qti-realtime to qcom-realtime

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -34,4 +34,4 @@ BBFILE_COLLECTIONS      += "qcom-realtime"
 BBFILE_PATTERN_qcom-realtime   = "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom-realtime  = "12"
 
-LAYERSERIES_COMPAT_qti-realtime = "kirkstone scarthgap"
+LAYERSERIES_COMPAT_qcom-realtime = "kirkstone scarthgap"


### PR DESCRIPTION
LAYERSERIES_COMPAT_qcom-realtime is the correct name we get a warning while building
WARNING: Layer qcom-realtime should set LAYERSERIES_COMPAT_qcom-realtime in its conf/layer.conf file to list the core layer names it is compatible with.