### PR TITLE
Create qcom-preflight-checks.yaml

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yaml
+++ b/.github/workflows/qcom-preflight-checks.yaml
@@ -1,0 +1,24 @@
+name: QC Preflight Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    with:
+      enable-semgrep-scan: false
+      enable-dependency-review: false
+      enable-repolinter-check: true
+      enable-copyright-license-check: false
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false
+
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
Introduced QC Preflight Checks Workflow

Introduced the QC Preflight Checks GitHub Actions workflow with the following updates and configurations:

Added the QC Preflight Checks workflow
Configured the workflow trigger to use pull_request instead of pull_request_target
(Security improvement: pull_request_target runs with write permissions and access to secrets, which is unsafe for untrusted PRs)
Integrated the v2 version of the reusable workflow (qcom-reusable-workflow)
Defined a single job named preflight
Added job display name: Run QC Preflight Checks

Adopted the new v2 input parameter format:
enable-semgrep-scan
enable-dependency-review
enable-repolinter-check
enable-copyright-license-check
enable-commit-email-check
enable-commit-msg-check
enable-armor-checkers

Removed SEMGREP_APP_TOKEN secret, as it is no longer required in v2

Enabled Checks

Only the following checks are enabled:
enable-repolinter-check: true
enable-commit-email-check: true

All other checks are explicitly disabled.
For more details, refer to the https://github.com/qualcomm/qcom-reusable-workflows